### PR TITLE
Resolved dark-mode persist issue

### DIFF
--- a/script.js
+++ b/script.js
@@ -510,17 +510,27 @@ function closeFeaturesPopup() {
 
 //Toggle function that is affected by the slider box
 // Check if there's a theme preference stored in localStorage
+// Check if there's a theme preference stored in localStorage
+// Check if there's a theme preference stored in localStorage
 var savedTheme = localStorage.getItem('theme');
+var slider = document.getElementById('themeToggle');
 
+// Set the toggle button state based on the saved theme preference
+if (savedTheme === 'dark-mode') {
+    slider.checked = true;
+} else {
+    slider.checked = false;
+}
+
+// Apply the theme based on the saved preference or default to light mode
 if (savedTheme) {
     document.body.className = savedTheme;
 } else {
-
     lightMode();
 }
 
+// Toggle between light and dark modes when the toggle button is clicked
 function toggleTheme() {
-    var slider = document.getElementById('themeToggle');
     if (slider.checked) {
         darkMode();
     } else {
@@ -530,6 +540,8 @@ function toggleTheme() {
     // Store the theme preference in localStorage
     localStorage.setItem('theme', document.body.className);
 }
+
+
 
 function darkMode() {
     let element = document.body;

--- a/script.js
+++ b/script.js
@@ -509,6 +509,16 @@ function closeFeaturesPopup() {
 }
 
 //Toggle function that is affected by the slider box
+// Check if there's a theme preference stored in localStorage
+var savedTheme = localStorage.getItem('theme');
+
+if (savedTheme) {
+    document.body.className = savedTheme;
+} else {
+
+    lightMode();
+}
+
 function toggleTheme() {
     var slider = document.getElementById('themeToggle');
     if (slider.checked) {
@@ -516,7 +526,11 @@ function toggleTheme() {
     } else {
         lightMode();
     }
+
+    // Store the theme preference in localStorage
+    localStorage.setItem('theme', document.body.className);
 }
+
 function darkMode() {
     let element = document.body;
     element.className = "dark-mode";


### PR DESCRIPTION
Hey @sk66641 ,
issue closes #223 
I have resolved the issue to persist the dark mode preference across page refreshes using localStorage.
The changes ensure that the user's selected mode (dark or light) is maintained even after the page is refreshed.

**Changes made are as follows :**

Added functionality to check "localStorage" for the user's dark mode preference upon page load and set the initial state accordingly.
Updated the event listener for the toggle switch to save the dark mode preference in localStorage whenever the user changes the mode.
Now, Whenever user will refresh or log in the page again, The selected mode preference will be the same as chosen.

Please take a look and review it.
Also, please add the labels.