### PR TITLE
FAQ box width fixed

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1876,6 +1876,11 @@ button:hover {
   padding-left: 0;
 } */
 
+@media screen and (max-width : 414px) {
+  .box {
+    width: 100%;
+  }
+}
 
 .box h1 {
   font-family: Arial, sans-serif;


### PR DESCRIPTION
# Description

Earlier the width of the FAQ box was looking weird for smaller mobile devices, I fixed it.

Fixes:  #428

<!---give the issue number you fixed----->

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
Before change:
![image](https://github.com/user-attachments/assets/1df23efa-a67d-409f-9b17-f098aa056f58)

After change:
![image](https://github.com/user-attachments/assets/1aea39e8-9504-49f1-ab56-6b3539453f94)
