### PR TITLE
Added mode toggler in privacy policy and Terms page

### DIFF
--- a/pages/privacy.html
+++ b/pages/privacy.html
@@ -156,6 +156,20 @@
             </p>
         </div>
     </footer>
+
+    <!-- Mode toggler -->
+    <label id="themeChangeToggle" class="theme-toggle" for="themeToggle" style="position: fixed; 
+        top: 30px; 
+        right: 30px; 
+        z-index: 100; 
+        display: flex; 
+        align-items: center; 
+        border: none; 
+        background-color: transparent;">
+        <input type="checkbox" id="themeToggle" onclick="toggleTheme()" checked aria-label="Switch theme mode">
+        <span class="slider" style="width: 40px; height: 20px;"></span>
+    </label>
+
     <script src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
     <script src="../js/background.js"></script>
     <script src="../js/script.js"></script>

--- a/pages/terms.html
+++ b/pages/terms.html
@@ -165,6 +165,21 @@
             </p>
         </div>
     </footer>
+
+    <!-- Mode toggler -->
+    <label id="themeChangeToggle" class="theme-toggle" for="themeToggle" style="position: fixed; 
+        top: 30px; 
+        right: 30px; 
+        z-index: 100; 
+        display: flex; 
+        align-items: center; 
+        border: none; 
+        background-color: transparent;">
+        <input type="checkbox" id="themeToggle" onclick="toggleTheme()" checked aria-label="Switch theme mode">
+        <span class="slider" style="width: 40px; height: 20px;"></span>
+    </label>
+
+
     <script src="https://cdn.jsdelivr.net/particles.js/2.0.0/particles.min.js"></script>
     <script src="../js/background.js"></script>
     <script src="../js/script.js"></script>


### PR DESCRIPTION
# Description

Prior to this change, there was no way to switch to light mode in the privacy-policy page (/pages/privacy.html) and terms-and-conditions page (/pages/terms.html)

Fixes:  #427 

<!---give the issue number you fixed----->

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
![image](https://github.com/user-attachments/assets/b70199ce-a1ab-4822-bc0f-65e64900748c)
