### PR TITLE
Removed Unnecessary Extra Spaces above Contributors Page in Mobile View

### DIFF
--- a/css/about.css
+++ b/css/about.css
@@ -159,6 +159,6 @@ strong{
 }
 @media only screen and (max-width:350px){
     body{
-        padding-top: 200px;
+        padding-top: 0px;
     }
 }


### PR DESCRIPTION
# Description

Hey @sk66641 and @aditya-bhaumik 

- issue closes #494 

I have removed unnecessary extra spaces above contributors page in mobile view

![image](https://github.com/user-attachments/assets/13cbea04-c612-4f8c-ad62-b0b71ba6fc35)


## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

