### PR TITLE
Issue #510

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -699,26 +699,6 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 window.onload = function () {
-    const modal = document.getElementById("warningModal");
-    const closeModal = document.getElementById("closeModal");
-    const proceedButton = document.getElementById("proceed");
-
-    modal.style.display = "block";
-
-    closeModal.onclick = function () {
-        modal.style.display = "none";
-    }
-
-    proceedButton.onclick = function () {
-        modal.style.display = "none";
-    }
-
-    window.onclick = function (event) {
-        if (event.target == modal) {
-            modal.style.display = "none";
-        }
-    }
-
     const words = ["Light Simulator", "Beat Spectrum"];
     let index = 0;
     let direction = "left";
@@ -885,10 +865,55 @@ function effect() {
 
 
 var loader = document.querySelector(".loader");
-window.addEventListener('load', () => {
-    var backToTopBtn = document.getElementById("backToTopBtn");
-    backToTopBtn.style.display = "none";
+
+document.addEventListener('DOMContentLoaded', function () {
+var backToTopBtn = document.getElementById("backToTopBtn");
+backToTopBtn.style.display = "none";
+const modal = document.getElementById("warningModal");
+const closeModal = document.getElementById("closeModal");
+const proceedButton = document.getElementById("proceed");
+
+if (!sessionStorage.getItem('loaderCompleted')) {
     setTimeout(effect, 4000);
+    setTimeout(() => {
+        document.querySelector(".navMain").style.visibility = "visible";
+        // backToTopBtn.style.display = "block";
+    }, 4000);
+
+    //execute only once per session, ie when loaderCompleted is not true
+    modal.style.display = "block";
+
+    //event listeners involved with the modal:
+    closeModal.onclick = function () {
+        modal.style.display = "none";
+    }
+
+    proceedButton.onclick = function () {
+        modal.style.display = "none";
+    }
+
+    window.onclick = function (event) {
+        if (event.target == modal) {
+            modal.style.display = "none";
+        }       
+    }
+}
+
+
+else{
+    effect();
+    //load content without timeout
+
+    modal.style.display = "none";
+    //warning modal is needed only once in a session
+    
+    document.querySelector(".navMain").style.visibility = "visible";
+    //no timeout function needed for nav in absence of loader animation
+
+    // backToTopBtn.style.display = "block";
+}
+
+sessionStorage.setItem('loaderCompleted', 'true');
 })
 
 function changeColor() {
@@ -898,7 +923,7 @@ function changeColor() {
 
 document.addEventListener("DOMContentLoaded", function () {
     var backToTopBtn = document.getElementById("backToTopBtn");
-    backToTopBtn.style.display = "block";
+    // backToTopBtn.style.display = "block";
     backToTopBtn.addEventListener("click", function () {
         scrollToTop();
         scrollToForm();


### PR DESCRIPTION
# Description

Used session storage to enable the loader only once per session, i.e. avoid loader when the user navigates to the home page from other side pages 

Accordingly adjusted the display of back to top button, nav menu and the warning modal ensuring that the set time out function on these elements is not executed on instances other than initial load

Fixes:  #510 

<!---give the issue number you fixed----->

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
