### PR TITLE
Fixed the overlapping of back to top button with other icons .

### DIFF
--- a/css/backToTopButton.css
+++ b/css/backToTopButton.css
@@ -1,9 +1,9 @@
 #backToTopBtn {
     position: fixed;
-    bottom: 130px;
+    bottom: 2px;
     right: 31px;
-    height: 50px;
-    width: 50px;
+    height: 42px;
+    width: 45px;
     padding: 10px 15px;
     font-size: 20px;
     cursor: pointer;


### PR DESCRIPTION
# Description
I have fixed the overlapping of back to top button with other icons in every page of the website .

Fixes:  #547

<!---give the issue number you fixed----->

## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


# ATTACH SCREEN-SHOTS / DEPLOYMENT LINK
![Screenshot (945)](https://github.com/user-attachments/assets/4c4eabf1-7b68-4b9d-8ed8-c67f710d6039)
![Screenshot (946)](https://github.com/user-attachments/assets/b0047068-5a2d-4d41-8a33-b9797db3609d)
