### PR TITLE
Add "Preloader" to All Pages (excluding Homepage) 

### DIFF
--- a/404.html
+++ b/404.html
@@ -12,9 +12,43 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
     <title>Error - 404</title>
     <script src="./js/404.js" defer></script>
+    <link rel="stylesheet" href="/css/preloader.css">
 </head>
 
 <body>
+
+    <!-- Preloader starts -->
+    <div id="preloader">
+        <div class="spinner">
+            <div class="spinner-inner"></div>
+            <div id="loading-percentage">0%</div>
+        </div>
+    </div>
+    <script>
+        window.addEventListener('load', () => {
+    const preloader = document.getElementById('preloader');
+    const content = document.getElementById('content');
+    const loadingPercentage = document.getElementById('loading-percentage');
+
+    let percentage = 0;
+
+    const interval = setInterval(() => {
+        percentage += 10; 
+        loadingPercentage.textContent = `${percentage}%`;
+        if (percentage >= 100) {
+            clearInterval(interval);
+            setTimeout(() => {
+                preloader.style.display = 'none';
+                content.style.display = 'block';
+                document.body.style.overflow = 'auto'; 
+            }, 300); 
+        }
+    }, 100); 
+});
+
+    </script>
+<!-- Preloader Ends -->
+<div id="content"> 
     <div class="errorpage"></div>
     <div class="stars"></div>
     <div class="container">
@@ -32,6 +66,7 @@
                 <span class="light-mode-icon"><img src="sun.svg" style = "display: block;"></span>
                 <span class="dark-mode-icon"><img src="moon.svg"style = "display: block;"></span>
             </div>
+</div>
 </body>
 
 </html>

--- a/css/preloader.css
+++ b/css/preloader.css
@@ -1,0 +1,58 @@
+#preloader {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 9999;
+}
+
+.spinner {
+    position: relative;
+    width: 130px; /* Size of the spinner */
+    height: 130px; /* Size of the spinner */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.spinner-inner {
+    width: 100px; /* Size of the spinner */
+    height: 100px; /* Size of the spinner */
+    border-radius: 50%; /* Makes the spinner circular */
+    border: 10px solid transparent; /* Base border to create space */
+    border-top: 10px solid transparent;
+    border-right: 10px solid transparent;
+    border-bottom: 10px solid transparent;
+    border-left: 10px solid transparent; /* Gradient applied here */
+    border-image: linear-gradient(45deg, #ff2d15, #be18ff, #0d3dff); /* Gradient border */
+    border-image-slice: 1;
+    animation: spin 1s linear infinite;
+}
+
+#loading-percentage {
+    position: absolute;
+    font-size: 24px;
+    font-weight: bold;
+    text-align: center;
+    width: 100%;
+    top: 50%;
+    transform: translateY(-50%);
+    background: linear-gradient(45deg, #be18ff, #ffffff); /* Gradient text color */
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent; /* Makes text color gradient */
+    color: transparent; /* Fallback for non-webkit browsers */
+}
+
+@keyframes spin {
+    0% { transform: rotate(0deg); }
+    100% { transform: rotate(360deg); }
+}
+
+#content {
+    display: none; /* Hide content until preloader is done */
+}

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta name="description" content="Experience the vibrant Random Disco Light Simulator! Enjoy dynamic, colorful light patterns and immerse yourself in a fun, party-like atmosphere.">
   <meta name="keywords" content="disco lights, light simulator, random disco lights, colorful lights, dynamic light patterns, party lights, interactive light effects, fun lighting, vibrant light show, random light patterns">
   <title>Random Disco Light Simulator</title>
-  <link rel="icon" type="image/x-icon" href="/assets/images/favicon.ico">
+  <link rel="icon" type="image/x-icon" href="../assets/images/favicon.ico">
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/backToTopButton.css">
   <link rel="stylesheet" href="./css/style.css">

--- a/pages/about.html
+++ b/pages/about.html
@@ -10,6 +10,7 @@
     <link rel="icon" type="image/x-icon" href="../assets/images/favicon.ico">
     <link rel="stylesheet" href="../css/style.css">
     <link rel="stylesheet" href="../css/about.css">
+    <link rel="stylesheet" href="../css/preloader.css">
     <link rel="stylesheet" href="../css/backToTopButton.css">
     <link rel="stylesheet" href="../css/backtohome.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
@@ -66,6 +67,40 @@
   </head>
   
   <body>
+
+
+ <!-- Preloader starts -->
+       <div id="preloader">
+        <div class="spinner">
+            <div class="spinner-inner"></div>
+            <div id="loading-percentage">0%</div>
+        </div>
+    </div>
+    <script>
+        window.addEventListener('load', () => {
+    const preloader = document.getElementById('preloader');
+    const content = document.getElementById('content');
+    const loadingPercentage = document.getElementById('loading-percentage');
+
+    let percentage = 0;
+
+    const interval = setInterval(() => {
+        percentage += 10; 
+        loadingPercentage.textContent = `${percentage}%`;
+        if (percentage >= 100) {
+            clearInterval(interval);
+            setTimeout(() => {
+                preloader.style.display = 'none';
+                content.style.display = 'block';
+                document.body.style.overflow = 'auto'; 
+            }, 300); 
+        }
+    }, 100); 
+});
+
+    </script>
+<!-- Preloader Ends -->
+
     <div class="circle-container">
       <div class="circle"></div>
       <div class="circle"></div>
@@ -138,6 +173,7 @@
     </script>
     <script src="../js/theme.js"></script>
 
+<div id="content"> 
     <span class="slider" style="width: 40px; height: 20px; display: none;"></span> 
         
     <div id="sun-moon-mode-toggler" class="toggle-container" >
@@ -271,5 +307,6 @@
             <p>Thank you for your continued support!</p>
         </div>
     </div>    
+</div>
 </body>
 </html>

--- a/pages/contributors.html
+++ b/pages/contributors.html
@@ -9,6 +9,7 @@
     <link rel="icon" type="image/x-icon" href="../assets/images/favicon.ico">
     <link rel="stylesheet" href="../css/style.css">
     <link rel="stylesheet" href="../css/backtohome.css">
+    <link rel="stylesheet" href="../css/preloader.css">
     <link rel="stylesheet" href="../css/about.css">
     <link rel="stylesheet" href="../css/contributors.css">
     <link rel="stylesheet" href="../css/backToTopButton.css">
@@ -106,6 +107,39 @@
       </head>
 
       <body>
+
+<!-- Preloader starts -->
+   <div id="preloader">
+    <div class="spinner">
+        <div class="spinner-inner"></div>
+        <div id="loading-percentage">0%</div>
+    </div>
+</div>
+<script>
+    window.addEventListener('load', () => {
+const preloader = document.getElementById('preloader');
+const content = document.getElementById('content');
+const loadingPercentage = document.getElementById('loading-percentage');
+
+let percentage = 0;
+
+const interval = setInterval(() => {
+    percentage += 10; 
+    loadingPercentage.textContent = `${percentage}%`;
+    if (percentage >= 100) {
+        clearInterval(interval);
+        setTimeout(() => {
+            preloader.style.display = 'none';
+            content.style.display = 'block';
+            document.body.style.overflow = 'auto'; 
+        }, 300); 
+    }
+}, 100); 
+});
+
+</script>
+<!-- Preloader Ends -->
+
         <div class="circle-container">
           <div class="circle"></div>
           <div class="circle"></div>
@@ -178,6 +212,7 @@
         </script>
         <script src="../js/theme.js"></script>
 
+<div id="content"> 
         <span class="slider" style="width: 40px; height: 20px; display: none;"></span> 
         
         <div id="sun-moon-mode-toggler" class="toggle-container" >
@@ -316,5 +351,6 @@
             <p>Thank you for your continued support! </p>
         </div>
     </div>
+</div>
 </body>
 </html>

--- a/pages/faq.html
+++ b/pages/faq.html
@@ -10,6 +10,7 @@
     <link rel="icon" type="image/x-icon" href="../assets/images/favicon.ico">
     <link rel="stylesheet" href="../css/style.css">
     <link rel="stylesheet" href="../css/faq.css">
+    <link rel="stylesheet" href="../css/preloader.css">
     <link rel="stylesheet" href="../css/backtohome.css">
     <link rel="stylesheet" href="../css/backToTopButton.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
@@ -98,6 +99,39 @@
       </head>
       
       <body>
+
+<!-- Preloader starts -->
+   <div id="preloader">
+    <div class="spinner">
+        <div class="spinner-inner"></div>
+        <div id="loading-percentage">0%</div>
+    </div>
+</div>
+<script>
+    window.addEventListener('load', () => {
+const preloader = document.getElementById('preloader');
+const content = document.getElementById('content');
+const loadingPercentage = document.getElementById('loading-percentage');
+
+let percentage = 0;
+
+const interval = setInterval(() => {
+    percentage += 10; 
+    loadingPercentage.textContent = `${percentage}%`;
+    if (percentage >= 100) {
+        clearInterval(interval);
+        setTimeout(() => {
+            preloader.style.display = 'none';
+            content.style.display = 'block';
+            document.body.style.overflow = 'auto'; 
+        }, 300); 
+    }
+}, 100); 
+});
+
+</script>
+<!-- Preloader Ends -->
+
         <div class="circle-container">
           <div class="circle"></div>
           <div class="circle"></div>
@@ -169,7 +203,8 @@
           });
         </script>
         <script src="../js/theme.js"></script>
-        
+
+<div id="content"> 
         <span class="slider" style="width: 40px; height: 20px; display: none;"></span> 
         
         <div id="sun-moon-mode-toggler" class="toggle-container" >
@@ -310,6 +345,7 @@
             <p>Thank you for your continued support!</p>
         </div>
     </div>
+</div>
 </body>
 
 </html>

--- a/pages/features.html
+++ b/pages/features.html
@@ -10,6 +10,7 @@
     <link rel="icon" type="image/x-icon" href="../assets/images/favicon.ico">
     <link rel="stylesheet" href="../css/style.css">
     <link rel="stylesheet" href="../css/backtohome.css">
+    <link rel="stylesheet" href="../css/preloader.css">
     <link rel="stylesheet" href="../css/features.css">
     <link rel="stylesheet" href="../css/backToTopButton.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
@@ -61,9 +62,41 @@
         </style>
       
       
-      </head>
-      
-      <body>
+</head>
+<body>
+
+<!-- Preloader starts -->
+    <div id="preloader">
+        <div class="spinner">
+            <div class="spinner-inner"></div>
+            <div id="loading-percentage">0%</div>
+        </div>
+    </div>
+    <script>
+        window.addEventListener('load', () => {
+    const preloader = document.getElementById('preloader');
+    const content = document.getElementById('content');
+    const loadingPercentage = document.getElementById('loading-percentage');
+
+    let percentage = 0;
+
+    const interval = setInterval(() => {
+        percentage += 10; 
+        loadingPercentage.textContent = `${percentage}%`;
+        if (percentage >= 100) {
+            clearInterval(interval);
+            setTimeout(() => {
+                preloader.style.display = 'none';
+                content.style.display = 'block';
+                document.body.style.overflow = 'auto'; 
+            }, 300); 
+        }
+    }, 100); 
+});
+
+    </script>
+<!-- Preloader Ends -->
+
         <div class="circle-container">
           <div class="circle"></div>
           <div class="circle"></div>
@@ -136,6 +169,7 @@
         </script>
     <script src="../js/theme.js"></script>
 
+<div id="content"> 
     <span class="slider" style="width: 40px; height: 20px; display: none;"></span> 
         
     <div id="sun-moon-mode-toggler" class="toggle-container" >
@@ -343,6 +377,7 @@
             <p>Thank you for your continued support! </p>
         </div>
     </div>
+</div>
 </body>
 
 </html>

--- a/pages/feedback.html
+++ b/pages/feedback.html
@@ -12,6 +12,7 @@
     <link rel="icon" type="image/x-icon" href="../assets/images/favicon.ico">
     <link rel="stylesheet" href="../css/style.css">
     <link rel="stylesheet" href="../css/feedback.css">
+    <link rel="stylesheet" href="../css/preloader.css">
     <link rel="stylesheet" href="../css/backtohome.css">
     <link rel="stylesheet" href="../css/backToTopButton.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
@@ -65,6 +66,39 @@
 </head>
 
 <body>
+
+    <!-- Preloader starts -->
+    <div id="preloader">
+        <div class="spinner">
+            <div class="spinner-inner"></div>
+            <div id="loading-percentage">0%</div>
+        </div>
+    </div>
+    <script>
+        window.addEventListener('load', () => {
+    const preloader = document.getElementById('preloader');
+    const content = document.getElementById('content');
+    const loadingPercentage = document.getElementById('loading-percentage');
+
+    let percentage = 0;
+
+    const interval = setInterval(() => {
+        percentage += 10; 
+        loadingPercentage.textContent = `${percentage}%`;
+        if (percentage >= 100) {
+            clearInterval(interval);
+            setTimeout(() => {
+                preloader.style.display = 'none';
+                content.style.display = 'block';
+                document.body.style.overflow = 'auto'; 
+            }, 300); 
+        }
+    }, 100); 
+});
+
+    </script>
+    <!-- Preloader Ends -->
+
     <div class="circle-container">
         <div class="circle"></div>
         <div class="circle"></div>
@@ -97,6 +131,9 @@
         <div class="circle"></div>
         <div class="circle"></div>
       </div>
+
+      <div id="content"> 
+
 
       <span class="slider" style="width: 40px; height: 20px; display: none;"></span> 
         
@@ -335,6 +372,7 @@
           animateCircles();
         });
       </script>
+ </div>
 </body>
 
 </html>

--- a/pages/privacy.html
+++ b/pages/privacy.html
@@ -9,6 +9,7 @@
     <link rel="icon" type="image/x-icon" href="../assets/images/favicon.ico">
     <link rel="stylesheet" href="../css/style.css">
     <link rel="stylesheet" href="../css/about.css">
+    <link rel="stylesheet" href="../css/preloader.css">
     <link rel="stylesheet" href="../css/backtohome.css">
     <link rel="stylesheet" href="../css/backToTopButton.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
@@ -69,6 +70,39 @@
     </style>
 </head>
 <body>
+
+    <!-- Preloader starts -->
+    <div id="preloader">
+        <div class="spinner">
+            <div class="spinner-inner"></div>
+            <div id="loading-percentage">0%</div>
+        </div>
+    </div>
+    <script>
+        window.addEventListener('load', () => {
+    const preloader = document.getElementById('preloader');
+    const content = document.getElementById('content');
+    const loadingPercentage = document.getElementById('loading-percentage');
+
+    let percentage = 0;
+
+    const interval = setInterval(() => {
+        percentage += 10; 
+        loadingPercentage.textContent = `${percentage}%`;
+        if (percentage >= 100) {
+            clearInterval(interval);
+            setTimeout(() => {
+                preloader.style.display = 'none';
+                content.style.display = 'block';
+                document.body.style.overflow = 'auto'; 
+            }, 300); 
+        }
+    }, 100); 
+});
+
+    </script>
+    <!-- Preloader Ends -->
+
     <div class="circle-container">
         <div class="circle"></div>
         <div class="circle"></div>
@@ -141,6 +175,7 @@
       </script>
       <script src="../js/theme.js"></script>
 
+<div id="content"> 
         <span class="slider" style="width: 40px; height: 20px; display: none;"></span> 
         
         <div id="sun-moon-mode-toggler" class="toggle-container" >
@@ -348,5 +383,6 @@
             <p>Thank you for your continued support! </p>
         </div>
     </div>
+</div>
 </body>
 </html>

--- a/pages/terms.html
+++ b/pages/terms.html
@@ -9,6 +9,7 @@
     <link rel="icon" type="image/x-icon" href="/assets/images/favicon.ico">
     <link rel="stylesheet" href="../css/style.css">
     <link rel="stylesheet" href="../css/backtohome.css">
+    <link rel="stylesheet" href="../css/preloader.css">
     <link rel="stylesheet" href="../css/about.css">
     <link rel="stylesheet" href="../css/backToTopButton.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
@@ -63,10 +64,42 @@
           font-weight: 400 !important;
         }
 
-
     </style>
 </head>
 <body>
+
+    <!-- Preloader starts -->
+    <div id="preloader">
+        <div class="spinner">
+            <div class="spinner-inner"></div>
+            <div id="loading-percentage">0%</div>
+        </div>
+    </div>
+    <script>
+        window.addEventListener('load', () => {
+    const preloader = document.getElementById('preloader');
+    const content = document.getElementById('content');
+    const loadingPercentage = document.getElementById('loading-percentage');
+
+    let percentage = 0;
+
+    const interval = setInterval(() => {
+        percentage += 10; 
+        loadingPercentage.textContent = `${percentage}%`;
+        if (percentage >= 100) {
+            clearInterval(interval);
+            setTimeout(() => {
+                preloader.style.display = 'none';
+                content.style.display = 'block';
+                document.body.style.overflow = 'auto'; 
+            }, 300); 
+        }
+    }, 100); 
+});
+
+    </script>
+    <!-- Preloader Ends -->
+
     <div class="circle-container">
         <div class="circle"></div>
         <div class="circle"></div>
@@ -138,6 +171,8 @@
         });
       </script>
       <script src="../js/theme.js"></script>
+    
+<div id="content"> 
        <span class="slider" style="width: 40px; height: 20px; display: none;"></span> 
         
        <div id="sun-moon-mode-toggler" class="toggle-container" >
@@ -352,5 +387,6 @@
             <p>Thank you for your continued support! </p>
         </div>
     </div>
+</div>
 </body>
 </html>

--- a/pages/terms.html
+++ b/pages/terms.html
@@ -6,7 +6,7 @@
     <meta name="author" content="Sanu Kumar">
     <meta name="description" content="Review the terms and conditions for using the Random Disco Light Simulator site and services.">
     <title>Terms - Random Disco Light Simulator</title>
-    <link rel="icon" type="image/x-icon" href="/assets/images/favicon.ico">
+    <link rel="icon" type="image/x-icon" href="../assets/images/favicon.ico">
     <link rel="stylesheet" href="../css/style.css">
     <link rel="stylesheet" href="../css/backtohome.css">
     <link rel="stylesheet" href="../css/preloader.css">


### PR DESCRIPTION
# Description

Hey @aditya-bhaumik @sk66641 

- issue fixes #563

I have added a preloader integrated with a load of percentage to all pages (excluding homepages)

- Added Preloaer which is a gradient of spinner `#ff2d15`, `#be18ff`, `#0d3dff`
- Integrated loader with `Percentage indicator: 0% to 100%` | Color gradient of `#be18ff`, `#ffffff`
- Added logic to display the preloader and update the loading percentage.
- Ensured the preloader hides and the content displays once loading is complete.
- Integrated in all pages
- Positioned in the center with `z-index: 9999;` to ensure it stays above.


https://github.com/user-attachments/assets/733197ae-c379-4da3-af22-32cecb514695


## Type of change

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

<!----Please delete options that are not relevant.And in order to tick the check box just but x inside them for example [x] like this----->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings


